### PR TITLE
modified wider search range of history

### DIFF
--- a/src/utils/history_manager.js
+++ b/src/utils/history_manager.js
@@ -8,7 +8,7 @@ export default class HistoryManager extends EventEmitter {
 
     const days = 30;
     const microsecondsBack = 1000 * 60 * 60 * 24 * days;
-    this.startTime = (new Date).getTime() - microsecondsBack;
+    this.startTime = Date.now() - microsecondsBack;
 
     const updateItems = this.updateItems.bind(this);
     updateItems();

--- a/src/utils/history_manager.js
+++ b/src/utils/history_manager.js
@@ -6,6 +6,10 @@ export default class HistoryManager extends EventEmitter {
     super();
     this.items = [];
 
+    const days = 30;
+    const microsecondsBack = 1000 * 60 * 60 * 24 * days;
+    this.startTime = (new Date).getTime() - microsecondsBack;
+
     const updateItems = this.updateItems.bind(this);
     updateItems();
     chrome.history.onVisited.addListener(updateItems);
@@ -19,7 +23,8 @@ export default class HistoryManager extends EventEmitter {
   updateItems() {
     chrome.history.search({
       text: '',
-      maxResults: MAX_HISTORY_RESULTS
+      maxResults: MAX_HISTORY_RESULTS,
+      startTime: this.startTime
     }, items => {
       this.items = items.map(item => {
         return {


### PR DESCRIPTION
https://developer.chrome.com/extensions/history

> double (optional) startTime
> Limit results to those visited after this date, represented in milliseconds since the epoch. If not specified, this defaults to 24 hours in the past.
